### PR TITLE
Parse sampling parameters for GLTF assets

### DIFF
--- a/src/io/gltf.rs
+++ b/src/io/gltf.rs
@@ -363,7 +363,7 @@ fn parse_texture<'a>(
 ) -> Result<Texture2D> {
     let gltf_image = gltf_texture.source();
     let gltf_source = gltf_image.source();
-    let mut tex = match gltf_source {
+    let mut tex: Texture2D = match gltf_source {
         ::gltf::image::Source::Uri { uri, .. } => {
             if uri.starts_with("data:") {
                 raw_assets.deserialize(uri)?

--- a/src/io/gltf.rs
+++ b/src/io/gltf.rs
@@ -345,6 +345,16 @@ fn parse_material(
     })
 }
 
+impl Into<Wrapping> for ::gltf::texture::WrappingMode {
+    fn into(self) -> Wrapping {
+        match self {
+            ::gltf::texture::WrappingMode::ClampToEdge => Wrapping::ClampToEdge,
+            ::gltf::texture::WrappingMode::MirroredRepeat => Wrapping::MirroredRepeat,
+            ::gltf::texture::WrappingMode::Repeat => Wrapping::Repeat,
+        }
+    }
+}
+
 fn parse_texture<'a>(
     raw_assets: &mut RawAssets,
     path: &Path,
@@ -353,7 +363,7 @@ fn parse_texture<'a>(
 ) -> Result<Texture2D> {
     let gltf_image = gltf_texture.source();
     let gltf_source = gltf_image.source();
-    let tex = match gltf_source {
+    let mut tex = match gltf_source {
         ::gltf::image::Source::Uri { uri, .. } => {
             if uri.starts_with("data:") {
                 raw_assets.deserialize(uri)?
@@ -373,7 +383,33 @@ fn parse_texture<'a>(
             super::img::deserialize_img("", &buffer[view.offset()..view.offset() + view.length()])?
         }
     };
-    // TODO: Parse sampling parameters
+
+    let sampler = gltf_texture.sampler();
+    tex.mag_filter = match sampler.mag_filter() {
+        Some(::gltf::texture::MagFilter::Nearest) => Interpolation::Nearest,
+        Some(::gltf::texture::MagFilter::Linear) => Interpolation::Linear,
+        None => tex.mag_filter,
+    };
+    (tex.min_filter, tex.mip_map_filter) = match sampler.min_filter() {
+        Some(::gltf::texture::MinFilter::Nearest) => (Interpolation::Nearest, None),
+        Some(::gltf::texture::MinFilter::Linear) => (Interpolation::Linear, None),
+        Some(::gltf::texture::MinFilter::NearestMipmapNearest) => {
+            (Interpolation::Nearest, Some(Interpolation::Nearest))
+        }
+        Some(::gltf::texture::MinFilter::LinearMipmapNearest) => {
+            (Interpolation::Linear, Some(Interpolation::Nearest))
+        }
+        Some(::gltf::texture::MinFilter::NearestMipmapLinear) => {
+            (Interpolation::Nearest, Some(Interpolation::Linear))
+        }
+        Some(::gltf::texture::MinFilter::LinearMipmapLinear) => {
+            (Interpolation::Linear, Some(Interpolation::Linear))
+        }
+        None => (tex.min_filter, tex.mip_map_filter),
+    };
+    tex.wrap_s = sampler.wrap_s().into();
+    tex.wrap_t = sampler.wrap_t().into();
+
     Ok(tex)
 }
 


### PR DESCRIPTION
Firstly, thanks for your work on this and [`three-d`](https://github.com/asny/three-d)!

I noticed when trying to render a model I made with some low resolution textures, that parsing the GLTF sampling options were a TODO.

This PR implements them.

An example of my specific use case:

| ![before](https://github.com/asny/three-d-asset/assets/65413190/786627db-5d03-4f5f-a856-60e50fd295bd) |![after](https://github.com/asny/three-d-asset/assets/65413190/21be7307-1dbd-4b0b-a04c-0669cc1ef384) |
|---|---|
| Before (`mag_filter` is always linear) | After (`mag_filter` correctly nearest-neighbour as specified by GLTF) |

I haven't tested the others (e.g. wrapping, mipmaps) concretely but they are implemented correctly as I understand them. Happy to ensure this is the case though.