### PR TITLE
fix: camera::rotate_around rotates by a smaller amount each time you use it

### DIFF
--- a/src/camera.rs
+++ b/src/camera.rs
@@ -618,7 +618,7 @@ impl Camera {
     ///
     pub fn rotate_around(&mut self, point: &Vec3, x: f32, y: f32) {
         let dir = (point - self.position()).normalize();
-        let right = dir.cross(*self.up());
+        let right = dir.cross(self.up().normalize());
         let up = right.cross(dir);
         let new_dir = (point - self.position() + right * x - up * y).normalize();
         let rotation = rotation_matrix_from_dir_to_dir(dir, new_dir);
@@ -633,7 +633,7 @@ impl Camera {
     ///
     pub fn rotate_around_with_fixed_up(&mut self, point: &Vec3, x: f32, y: f32) {
         let dir = (point - self.position()).normalize();
-        let right = dir.cross(*self.up());
+        let right = dir.cross(self.up().normalize());
         let mut up = right.cross(dir);
         let new_dir = (point - self.position() + right * x - up * y).normalize();
         up = *self.up();


### PR DESCRIPTION
As detailed in [this issue](https://github.com/asny/three-d/issues/405), a bug in the rotating code makes the function be less and less effective as time goes on. That is to say, the more you rotate around, without making any other changes, the slower it goes. I found it was because the `up` vector of the camera object is being set to without being normalized first, making its magnitude slightly different every frame. Normalizing it before calculating the cross product in the code fixes this issue.