### PR TITLE
Add rustls flavor of http feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,8 @@ all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
 [features]
-http = ["reqwest"]
+http = ["reqwest/default-tls"]
+http-rustls = ["reqwest/rustls-tls"]
 data-url = ["dep:data-url"]
 
 png = ["image/png"]
@@ -43,7 +44,7 @@ serde = ["dep:serde", "half/serde", "cgmath/serde"]
 cgmath = "0.18"
 half = {version="2", features=["std", "num-traits", "zerocopy"]}
 thiserror = "1"
-reqwest = {version = "0.11", optional = true }
+reqwest = {version = "0.11", optional = true, default-features = false }
 gltf = { version = "1", optional = true, features=["KHR_materials_ior", "KHR_materials_transmission"] }
 wavefront_obj = { version = "10", optional = true }
 image = { version = "0.24", optional = true, default-features = false}


### PR DESCRIPTION
This PR adds a feature "http-rustls" that uses rustls flavor of reqwest crate instead of native-tls. This is helpful for projects that would like to get rid of OpenSSL for various reasons.

Existing feature "http" is unchanged.