### PR TITLE
Use Rodrigues' rotation formula in rotate_around_with_fixed_up

### DIFF
--- a/src/camera.rs
+++ b/src/camera.rs
@@ -638,11 +638,12 @@ impl Camera {
         // subtract the point, do all rotations, and add the point again
         let position = self.position() - point;
         let target = self.target() - point;
+        let up = self.up.normalize();
         // We use Rodrigues' rotation formula to rotate around the fixed `up` vector and around the
         // horizon which is calculated from the camera's view direction and `up`
         // https://en.wikipedia.org/wiki/Rodrigues%27_rotation_formula
-        let k_x = self.up.normalize();
-        let k_y = (target - position).normalize().cross(self.up);
+        let k_x = up;
+        let k_y = (target - position).cross(up).normalize();
         // Prepare cos and sin terms, inverted because the method rotates left and up while
         // rotations follow the right hand rule
         let cos_x = (-x).cos();
@@ -657,8 +658,8 @@ impl Camera {
         let position_y = rodrigues(position_x, k_y, cos_y, sin_y);
         let target_y = rodrigues(target_x, k_y, cos_y, sin_y);
         // Forbid to face the camera exactly up or down, fall back to just rotate in x direction
-        let new_dir = target_y - position_y;
-        if new_dir.dot(self.up).abs() < 0.999 {
+        let new_dir = (target_y - position_y).normalize();
+        if new_dir.dot(up).abs() < 0.999 {
             self.set_view(position_y + point, target_y + point, self.up);
         } else {
             self.set_view(position_x + point, target_x + point, self.up);


### PR DESCRIPTION
I was confused how the rotations in my custom camera controller work. In Fusion360 (which served as my inspiration), orbiting always keeps the origin in the same spot, so orbiting right or left keeps the height constant, orbiting up or down rotates around a horizon through the origin.

In my implementation, I chose the origin as target to the `OrbitLeft` and `OrbitUp` actions:
```rust
            right_drag_horizontal: CameraAction::OrbitLeft {
                target: origin,
                speed,
            },

```
But the resulting controller moves my origin in unexpected weird ways whenever the origin is not in the camera center anymore. It is actually debatable which exact behaviour is desired here but in one of my tests, I have disabled the `OrbitUp` action altogether and the implemented `OrbitLeft` action dragged my camera towards the ground plane over time. This definitely feels wrong.

I have published my test code under https://github.com/embedded-rust-iml/three-d-asset-camera-control-example. You can pan the axes out of the camera center using middle-drag and orbit around using right-drag, then compare that behaviour to the behaviour when using the implementation here as dependency to the `three-d` dependency. (Edit: I have force-pushed, the example uses our forked `three-d-asset` via a forked `three-d` by default now, this can be changed in `Cargo.toml`.)

For me, this implementation works nicely but I do not have enough overview over the codebase to evaluate if this breaks other stuff, especially the other camera controls. If there seem to be any issues with anything or you need more information, please let me know.