### PR TITLE
Add information on STL model loading to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,9 +17,10 @@ When in memory, the assets can be for example be
 ### Model
 
 | Format   | Deserialize | Serialize | Feature |
-| -------- | ----------- | --------- | ------- |
-| OBJ/MTL  | ✅          | ❌        | `obj`   |
-| GLTF/GLB | ✅          | ❌        | `gltf`  |
+|----------|-------------|-----------|---------|
+| OBJ/MTL  | ✅          | ❌        | `obj`   |
+| GLTF/GLB | ✅          | ❌        | `gltf`  |
+| STL      | ✅          | ❌        | `stl`   |
 
 ### Texture2D
 


### PR DESCRIPTION
Noticed that I forgot this in the last PR. Like the title says, document that there is STL model loading support in readme 🙂 