### PR TITLE
SVG deserialization support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,8 @@ tga = ["image/tga"]
 gif = ["image/gif"]
 bmp = ["image/bmp"]
 
+svg = ["dep:resvg"]
+
 obj = ["wavefront_obj"]
 gltf = ["dep:gltf"]
 stl = ["dep:stl_io"]
@@ -50,6 +52,7 @@ gltf = { version = "1", optional = true, features=["KHR_materials_ior", "KHR_mat
 wavefront_obj = { version = "10", optional = true }
 stl_io = { version = "0.8.2", optional = true }
 image = { version = "0.24", optional = true, default-features = false}
+resvg = { version = "0.43.0", optional = true }
 pcd-rs = { version = "0.10", optional = true, features = ["derive"] }
 data-url = {version = "0.3", optional = true }
 serde = {version= "1", optional = true, features = ["derive", "rc"] }

--- a/README.md
+++ b/README.md
@@ -25,14 +25,15 @@ When in memory, the assets can be for example be
 ### Texture2D
 
 | Format | Deserialize | Serialize | Feature |
-| ------ | ----------- | --------- | ------- |
+|--------|-------------|-----------|---------|
 | PNG    | ✅          | ✅        | `png`   |
-| JPEG   | ✅          | ✅        |  `jpeg` |
+| JPEG   | ✅          | ✅        | `jpeg`  |
 | HDR    | ✅          | ❌        | `hdr`   |
 | GIF    | ✅          | ✅        | `gif`   |
 | TGA    | ✅          | ✅        | `tga`   |
 | TIFF   | ✅          | ✅        | `tiff`  |
 | BMP    | ✅          | ✅        | `bmp`   |
+| SVG    | ✅          | ❌        | `svg`   |
 
 ### PointCloud
 

--- a/src/io.rs
+++ b/src/io.rs
@@ -133,16 +133,20 @@ use std::path::{Path, PathBuf};
 impl Deserialize for crate::Texture2D {
     fn deserialize(path: impl AsRef<std::path::Path>, raw_assets: &mut RawAssets) -> Result<Self> {
         let path = raw_assets.match_path(path.as_ref())?;
+        let extension = path
+            .extension()
+            .map(|e| e.to_str().unwrap())
+            .unwrap_or("image")
+            .to_string();
         #[allow(unused_variables)]
         let bytes = raw_assets.get(&path)?;
 
         #[cfg(not(feature = "image"))]
-        return Err(Error::FeatureMissing(
-            path.extension()
-                .map(|e| e.to_str().unwrap())
-                .unwrap_or("image")
-                .to_string(),
-        ));
+        return Err(Error::FeatureMissing(extension));
+
+        if cfg!(feature = "svg") && "svg" == extension {
+            return img::deserialize_svg(path, bytes);
+        }
 
         #[cfg(feature = "image")]
         img::deserialize_img(path, bytes)

--- a/src/io.rs
+++ b/src/io.rs
@@ -141,15 +141,20 @@ impl Deserialize for crate::Texture2D {
         #[allow(unused_variables)]
         let bytes = raw_assets.get(&path)?;
 
-        #[cfg(not(feature = "image"))]
-        return Err(Error::FeatureMissing(extension));
-
         if cfg!(feature = "svg") && "svg" == extension {
-            return img::deserialize_svg(path, bytes);
-        }
+            // to satisfy the compiler during wasm compile
+            #[cfg(not(feature = "svg"))]
+            return Err(Error::FeatureMissing("svg".to_string()));
 
-        #[cfg(feature = "image")]
-        img::deserialize_img(path, bytes)
+            #[cfg(feature = "svg")]
+            return img::deserialize_svg(path, bytes);
+        } else {
+            #[cfg(not(feature = "image"))]
+            return Err(Error::FeatureMissing(extension));
+
+            #[cfg(feature = "image")]
+            return img::deserialize_img(path, bytes);
+        }
     }
 }
 

--- a/src/io.rs
+++ b/src/io.rs
@@ -141,19 +141,19 @@ impl Deserialize for crate::Texture2D {
         #[allow(unused_variables)]
         let bytes = raw_assets.get(&path)?;
 
-        if cfg!(feature = "svg") && "svg" == extension {
+        if "svg" == extension {
             // to satisfy the compiler during wasm compile
             #[cfg(not(feature = "svg"))]
             return Err(Error::FeatureMissing("svg".to_string()));
 
             #[cfg(feature = "svg")]
-            return img::deserialize_svg(path, bytes);
+            img::deserialize_svg(path, bytes)
         } else {
             #[cfg(not(feature = "image"))]
             return Err(Error::FeatureMissing(extension));
 
             #[cfg(feature = "image")]
-            return img::deserialize_img(path, bytes);
+            img::deserialize_img(path, bytes)
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -218,6 +218,11 @@ pub enum Error {
     #[cfg(feature = "image")]
     #[error("error while parsing an image file")]
     Image(#[from] image::ImageError),
+
+    #[cfg(feature = "svg")]
+    #[error("error while parsing svg file")]
+    Svg(#[from] resvg::usvg::Error),
+
     #[cfg(feature = "obj")]
     #[error("error while parsing an .obj file")]
     Obj(#[from] wavefront_obj::ParseError),

--- a/test_data/test.svg
+++ b/test_data/test.svg
@@ -1,0 +1,10 @@
+<?xml version="1.0"?>
+<svg width="320" height="240" xmlns="http://www.w3.org/2000/svg" xmlns:svg="http://www.w3.org/2000/svg">
+ <!-- Created with SVG-edit - https://github.com/SVG-Edit/svgedit-->
+ <g class="layer">
+  <title>Ellipses</title>
+  <ellipse cx="85" cy="85.5" fill="#0033ff" id="svg_1" rx="57" ry="47.5" stroke="#000000" stroke-width="5" transform="matrix(1 0 0 1 0 0)"/>
+  <ellipse cx="174" cy="168" fill="#00ff00" id="svg_2" rx="57" ry="47.5" stroke="#000000" stroke-width="5"/>
+  <ellipse cx="222" cy="70" fill="#FF0000" id="svg_3" rx="57" ry="47.5" stroke="#000000" stroke-width="5" transform="matrix(1 0 0 1 0 0)"/>
+ </g>
+</svg>


### PR DESCRIPTION
## Information
My attempt at supporting SVG loading as part of the resource pipeline. Works with both desktop/native build and wasm. Needs only the `resvg` crate to do so. 

Read in the linked issue in #4 that users wanted SVGs automatically rendered to a texture. That is what I have tried (and in my view succeeded) to accomplish here 🙂 

The code in `Deserialize` for `Texture2D` might be refactored, but found no prettier way to do it right now.

Fixes #4 


## Testing
Simply modified the logo example in `three-d` to only show the colors of the image. (that examples fragment shader does some minor processing I did not look into, but simply removed when testing). 

Loaded the following image from wikimedia for testing wasm build, as it doesn't seem like the local resources were included.
https://upload.wikimedia.org/wikipedia/commons/5/54/Bot%C3%B3n_Me_gusta.svg

wasm:
![image](https://github.com/user-attachments/assets/8a2b8341-c064-49ab-8c55-8e27083408fb)

native on Mac OS X (with the test.svg image included here):
<img width="508" alt="image" src="https://github.com/user-attachments/assets/878ef246-6b55-452c-aa2c-e6e1dee3235f">

Image is probably stretched a tiny bit in both cases, but mostly so on the native version.
