### PR TITLE
Scale camera zoom based on distance to target

### DIFF
--- a/src/camera.rs
+++ b/src/camera.rs
@@ -670,6 +670,7 @@ impl Camera {
 
     ///
     /// Moves the camera towards the given point by the amount delta while keeping the given minimum and maximum distance to the point.
+    /// Note that the camera target is also updated so that the view direction is the same.
     ///
     pub fn zoom_towards(
         &mut self,
@@ -686,11 +687,12 @@ impl Camera {
 
         let position = *self.position();
         let distance = point.distance(position);
-        let direction = (point - position).normalize();
-        let target = self.target;
-        let up = self.up;
-        let new_distance = (distance - delta).clamp(minimum_distance, maximum_distance);
-        let new_position = point - direction * new_distance;
-        self.set_view(new_position, target, up);
+        let delta_clamped = distance - (distance - delta).clamp(minimum_distance, maximum_distance);
+        let v = (point - position) * delta_clamped / distance;
+        self.set_view(
+            self.position + v,
+            self.target + v - v.project_on(self.view_direction()),
+            self.up,
+        );
     }
 }

--- a/src/camera.rs
+++ b/src/camera.rs
@@ -298,6 +298,7 @@ impl Camera {
             Point3::from_vec(self.target),
             self.up,
         );
+        self.view.w.w *= position.distance(target);
         self.update_screen2ray();
         self.update_frustrum();
     }
@@ -685,16 +686,10 @@ impl Camera {
         let position = *self.position();
         let distance = point.distance(position);
         let direction = (point - position).normalize();
-        let target = *self.target();
+        let target = self.target;
         let up = self.up;
         let new_distance = (distance - delta).clamp(minimum_distance, maximum_distance);
         let new_position = point - direction * new_distance;
-        self.set_view(new_position, new_position + (target - position), up);
-        if let ProjectionType::Orthographic { height } = self.projection_type() {
-            let h = new_distance * height / distance;
-            let z_near = self.z_near();
-            let z_far = self.z_far();
-            self.set_orthographic_projection(h, z_near, z_far);
-        }
+        self.set_view(new_position, target, up);
     }
 }

--- a/src/camera.rs
+++ b/src/camera.rs
@@ -298,7 +298,7 @@ impl Camera {
             Point3::from_vec(self.target),
             self.up,
         );
-        self.view.w.w *= position.distance(target);
+        self.view[3][3] *= position.distance(target);
         self.update_screen2ray();
         self.update_frustrum();
     }
@@ -550,6 +550,7 @@ impl Camera {
 
     fn update_screen2ray(&mut self) {
         let mut v = self.view;
+        v /= v[3][3];
         if let ProjectionType::Perspective { .. } = self.projection_type {
             v[3] = vec4(0.0, 0.0, 0.0, 1.0);
         }

--- a/src/camera.rs
+++ b/src/camera.rs
@@ -669,6 +669,14 @@ impl Camera {
     }
 
     ///
+    /// Moves the camera towards the camera target by the amount delta while keeping the given minimum and maximum distance to the target.
+    ///
+    pub fn zoom(&mut self, delta: f32, minimum_distance: f32, maximum_distance: f32) {
+        let target = self.target;
+        self.zoom_towards(&target, delta, minimum_distance, maximum_distance);
+    }
+
+    ///
     /// Moves the camera towards the given point by the amount delta while keeping the given minimum and maximum distance to the point.
     /// Note that the camera target is also updated so that the view direction is the same.
     ///

--- a/src/camera.rs
+++ b/src/camera.rs
@@ -695,12 +695,15 @@ impl Camera {
 
         let position = *self.position();
         let distance = point.distance(position);
-        let delta_clamped = distance - (distance - delta).clamp(minimum_distance, maximum_distance);
-        let v = (point - position) * delta_clamped / distance;
-        self.set_view(
-            self.position + v,
-            self.target + v - v.project_on(self.view_direction()),
-            self.up,
-        );
+        if distance > f32::EPSILON {
+            let delta_clamped =
+                distance - (distance - delta).clamp(minimum_distance, maximum_distance);
+            let v = (point - position) * delta_clamped / distance;
+            self.set_view(
+                self.position + v,
+                self.target + v - v.project_on(self.view_direction()),
+                self.up,
+            );
+        }
     }
 }


### PR DESCRIPTION
This causes the distance between the camera position and the camera target to affect the scale at which geometry is projected through the camera. Zooming was also changed to not affect the position of the view target, which in combination with the scaling removes the need to dynamically change the orthographic camera height.

For all cameras, this scales the effective far and near plane distances. Perspective cameras are otherwise unaffected visually. 2D cameras left at the default position are not affected at all. The default height of orthographic cameras will need to be divided by their initial distance to the target to maintain the same appearance.

This is motivated by a combination perspective/orthographic camera I am developing, which would otherwise require both a FOV and height parameter and be dynamically rescaled similar to what is done for the current orthographic camera.