### PR TITLE
Add support anisotropic filtering and for limiting the maximum number of mipmaps

### DIFF
--- a/src/texture/texture2d.rs
+++ b/src/texture/texture2d.rs
@@ -21,10 +21,14 @@ pub struct Texture2D {
     pub mag_filter: Interpolation,
     /// Specifies whether mipmaps should be created for this texture and what type of interpolation to use between the two closest mipmaps.
     pub mip_map_filter: Option<Interpolation>,
+    /// Specifies the maximum number of mipmaps that can be created for this texture.
+    pub mip_map_limit: Option<u32>,
     /// Determines how the texture is sampled outside the [0..1] s coordinate range (the first value of the uv coordinates).
     pub wrap_s: Wrapping,
     /// Determines how the texture is sampled outside the [0..1] t coordinate range (the second value of the uv coordinates).
     pub wrap_t: Wrapping,
+    /// Specifies the level of anisotropic filtering to be applied.
+    pub anisotropic_filter: Option<u32>,
 }
 
 impl Default for Texture2D {
@@ -37,8 +41,10 @@ impl Default for Texture2D {
             min_filter: Interpolation::Linear,
             mag_filter: Interpolation::Linear,
             mip_map_filter: Some(Interpolation::Linear),
+            mip_map_limit: None,
             wrap_s: Wrapping::Repeat,
             wrap_t: Wrapping::Repeat,
+            anisotropic_filter: None,
         }
     }
 }

--- a/src/texture/texture3d.rs
+++ b/src/texture/texture3d.rs
@@ -23,12 +23,16 @@ pub struct Texture3D {
     pub mag_filter: Interpolation,
     /// Specifies whether mipmaps should be created for this texture and what type of interpolation to use between the two closest mipmaps.
     pub mip_map_filter: Option<Interpolation>,
+    /// Specifies the maximum number of mipmaps that can be created for this texture.
+    pub mip_map_limit: Option<u32>,
     /// Determines how the texture is sampled outside the [0..1] s coordinate range (the first value of the uvw coordinates).
     pub wrap_s: Wrapping,
     /// Determines how the texture is sampled outside the [0..1] t coordinate range (the second value of the uvw coordinates).
     pub wrap_t: Wrapping,
     /// Determines how the texture is sampled outside the [0..1] r coordinate range (the third value of the uvw coordinates).
     pub wrap_r: Wrapping,
+    /// Specifies the level of anisotropic filtering to be applied.
+    pub anisotropic_filter: Option<u32>,
 }
 
 impl Default for Texture3D {
@@ -42,9 +46,11 @@ impl Default for Texture3D {
             min_filter: Interpolation::Linear,
             mag_filter: Interpolation::Linear,
             mip_map_filter: Some(Interpolation::Linear),
+            mip_map_limit: None,
             wrap_s: Wrapping::Repeat,
             wrap_t: Wrapping::Repeat,
             wrap_r: Wrapping::Repeat,
+            anisotropic_filter: None,
         }
     }
 }


### PR DESCRIPTION
Limiting the number of mip maps can be useful when dealing with large textures or ones that are updated every frame (e.g. shadow maps) to avoid performance overhead.

Anisotropic filtering requires an extension, however that is pretty much available everywhere and is also supported in WebGL / GL ES contexts.

See also the corresponding changes in `three-d` APIs here:  https://github.com/asny/three-d/pull/502

