### PR TITLE
Add custom projection support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,6 +56,7 @@ resvg = { version = "0.44", optional = true }
 pcd-rs = { version = "0.12", optional = true, features = ["derive"] }
 data-url = {version = "0.3", optional = true }
 serde = {version= "1", optional = true, features = ["derive", "rc"] }
+dyn-clone = { version = "1.0" }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 web-sys = { version = "0.3", features = ['Document', 'Window'] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,12 +41,13 @@ pcd = ["pcd-rs"]
 
 vol = []
 
-serde = ["dep:serde", "half/serde", "cgmath/serde"]
+serde = ["dep:serde", "dep:typetag", "half/serde", "cgmath/serde"]
 
 [dependencies]
 cgmath = "0.18"
 half = {version="2", features=["std", "num-traits", "zerocopy"]}
 thiserror = "2"
+dyn-clone = { version = "1.0" }
 reqwest = {version = "0.12", optional = true, default-features = false }
 gltf = { version = "1", optional = true, features=["KHR_materials_ior", "KHR_materials_transmission"] }
 wavefront_obj = { version = "10", optional = true }
@@ -56,7 +57,7 @@ resvg = { version = "0.44", optional = true }
 pcd-rs = { version = "0.12", optional = true, features = ["derive"] }
 data-url = {version = "0.3", optional = true }
 serde = {version= "1", optional = true, features = ["derive", "rc"] }
-dyn-clone = { version = "1.0" }
+typetag = { version = "0.2", optional = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 web-sys = { version = "0.3", features = ['Document', 'Window'] }

--- a/src/camera.rs
+++ b/src/camera.rs
@@ -212,6 +212,7 @@ impl Frustum {
 ///
 /// A general 3D to 2D projection, as used by [`Camera`](Camera::set_custom_projection). Custom projections should implement this trait.
 ///
+#[cfg_attr(feature = "serde", typetag::serde)]
 pub trait Projection: DynClone + Any + Debug {
     ///
     /// Generates a projection matrix from the provided zoom factor (if required), aspect ratio, and near/far plane distances
@@ -275,6 +276,7 @@ pub enum ProjectionType {
     },
 }
 
+#[cfg_attr(feature = "serde", typetag::serde)]
 impl Projection for ProjectionType {
     fn generate(&self, zoom: Option<f32>, aspect: f32, z_near: f32, z_far: f32) -> Mat4 {
         match self {


### PR DESCRIPTION
As an alternative to #45, this adds support for custom projections. All required projection functionality is made accessible through the `Projection` trait, which `ProjectionType` now implements. Additionally `ProjectionType` has a third `Custom` variant added to it which wraps a boxed `Projection` to store and delegate to user-defined projections.

I still have some cleanup I would like to do on `Camera`, hence this is a draft PR at the moment. Also, it may be good to move `Projection` and related types into a separate module.