### PR TITLE
update wavefront_obj dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,7 @@ half = {version="2", features=["std", "num-traits", "zerocopy"]}
 thiserror = "2"
 reqwest = {version = "0.12", optional = true, default-features = false }
 gltf = { version = "1", optional = true, features=["KHR_materials_ior", "KHR_materials_transmission"] }
-wavefront_obj = { version = "10", optional = true }
+wavefront_obj = { version = "11.0", optional = true }
 stl_io = { version = "0.8", optional = true }
 image = { version = "0.25", optional = true, default-features = false}
 resvg = { version = "0.44", optional = true }


### PR DESCRIPTION
`wavefront_obj` `10.0.0` has a dependency on `lexical` `5.2`, which has soundness issues: https://rustsec.org/advisories/RUSTSEC-2023-0055

Fixes #28.