### PR TITLE
Screen ray rewrite

### DIFF
--- a/src/camera.rs
+++ b/src/camera.rs
@@ -1,6 +1,5 @@
-use std::ops::Mul;
-
 pub use crate::prelude::*;
+use std::ops::Mul;
 
 /// UV coordinates which must be between `(0, 0)` indicating the bottom left corner
 /// and `(1, 1)` indicating the top right corner.
@@ -549,7 +548,9 @@ impl Camera {
     /// Returns the inverse view matrix, ie. the matrix that transforms objects from view space to world space. Closely related to [view](Camera::view).
     ///
     pub fn inverse_view(&self) -> Mat4 {
-        self.view.inverse_transform().expect("Non-invertible view transform")
+        self.view
+            .inverse_transform()
+            .expect("Non-invertible view transform")
     }
 
     ///


### PR DESCRIPTION
The way screen rays was originally calculated for planar cameras was incorrect due to the placement of the fixed plane at the view target instead of at the camera position. Calculating the correct position/view_direction for the planar camera from the projection matrix was getting complex, so I instead rewrote the logic to directly calculate the projection's effect on the view direction and position, later modified by the current view transform. I tested all three projections with the picking example to verify that the new math works correctly.