### PR TITLE
Add tolerance to jpeg serialization test

### DIFF
--- a/src/io/img.rs
+++ b/src/io/img.rs
@@ -192,6 +192,8 @@ pub fn serialize_img(tex: &Texture2D, path: &Path) -> Result<RawAssets> {
 
 #[cfg(test)]
 mod test {
+    use cgmath::AbsDiffEq;
+
     fn tex() -> crate::Texture2D {
         crate::Texture2D {
             data: crate::TextureData::RgbaU8(vec![
@@ -213,10 +215,10 @@ mod test {
         if format == "jpeg" || format == "jpg" {
             if let crate::TextureData::RgbU8(data) = tex.data {
                 // Jpeg is not lossless
-                assert_eq!(
-                    data,
-                    vec![[48, 0, 17], [227, 0, 14], [0, 244, 0], [16, 36, 253]]
-                );
+                assert!(data
+                    .iter()
+                    .zip(vec![[48, 0, 17], [227, 0, 14], [0, 244, 0], [16, 36, 253]].iter())
+                    .all(|(data_pixel, test_pixel)| data_pixel.abs_diff_eq(test_pixel, 2)));
             } else {
                 panic!("Wrong texture data: {:?}", tex.data)
             }


### PR DESCRIPTION
Since JPEG is a lossy format, the serialization test occasionally breaks as the exact optimization parameters are tweaked. This adds a slight bit of tolerance to the comparison using `abs_diff_eq` to capture these variances as a successful test case.