### PR TITLE
Make intersect return type option

### DIFF
--- a/src/prelude/aabb.rs
+++ b/src/prelude/aabb.rs
@@ -118,14 +118,14 @@ impl AxisAlignedBoundingBox {
     }
 
     /// Returns the intersection between this and the other given bounding box.
-    pub fn intersection(self, other: Self) -> Self {
+    pub fn intersection(self, other: Self) -> Option<Self> {
         let min_a = self.min();
         let max_a = self.max();
         let min_b = other.min();
         let max_b = other.max();
 
         if min_a.x >= max_b.x || min_a.y >= max_b.y || min_b.x >= max_a.x || min_b.y >= max_a.y {
-            return Self::EMPTY;
+            return None;
         }
 
         let min = vec3(
@@ -139,7 +139,7 @@ impl AxisAlignedBoundingBox {
             max_a.z.min(max_b.z),
         );
 
-        Self::new_with_positions(&[min, max])
+        Some(Self::new_with_positions(&[min, max]))
     }
 
     ///


### PR DESCRIPTION
Hello,

I would suggest modifying the response type of aabb.intersection to return None if there is no intersection, due to cleaner matching against intersection vs no intersection.

The change itself is really small, but unfortunately of course breaks the API. Please let me know, if you would be willing to accept this as is, or with additional changes.