### PR TITLE
Ply: optimise memory usage

### DIFF
--- a/src/geometry/point_cloud.rs
+++ b/src/geometry/point_cloud.rs
@@ -27,7 +27,7 @@ pub struct PointCloud {
     pub dc_spherical_harmonics: Option<Vec<Vec3>>,
 
     /// Spherical harmonic coefficients
-    pub spherical_harmonics: Option<Vec<Vec<f32>>>,
+    pub spherical_harmonics: Option<Vec<f32>>,
 }
 
 impl std::fmt::Debug for PointCloud {

--- a/src/io/ply.rs
+++ b/src/io/ply.rs
@@ -1,18 +1,105 @@
 use crate::geometry::{Geometry, PointCloud, Positions};
 use crate::prelude::*;
 use crate::{io::RawAssets, Node, Result, Scene};
-use ply_rs_bw::parser::Parser;
-use ply_rs_bw::ply::{DefaultElement, PropertyAccess};
+use ply_rs_bw::parser::{Parser, Reader};
+use ply_rs_bw::ply::{ PropertyAccess, PropertyAccessResult};
 use std::io::Cursor;
 use std::path::PathBuf;
+
+const MAX_SH:usize = 45;
+
+struct GsSplat {
+    position: [f32; 3],
+    rotation: [f32; 4],
+    scale: [f32; 3],
+    opacity: f32,
+    f_dc: [f32; 3],
+    f_rest: [f32; MAX_SH],
+    red: u8,
+    green: u8,
+    blue: u8,
+}
+
+impl PropertyAccess for GsSplat {
+    fn new() -> Self {
+        Self {
+            position: [0.0, 0.0, 0.0],
+            rotation: [1.0, 0.0, 0.0, 0.0],
+            scale: [1.0, 1.0, 1.0],
+            opacity: 1.0,
+            f_dc: [0.0, 0.0, 0.0],
+            f_rest: [0.0; MAX_SH],
+            red: 0,
+            green: 0,
+            blue: 0,
+        }
+    }
+
+    fn set_float(&mut self, key: &str, value: f32) -> PropertyAccessResult {
+        match key {
+            "x" => self.position[0] = value,
+            "y" => self.position[1] = value,
+            "z" => self.position[2] = value,
+            "rot_0" => self.rotation[0] = value,
+            "rot_1" => self.rotation[1] = value,
+            "rot_2" => self.rotation[2] = value,
+            "rot_3" => self.rotation[3] = value,
+            "scale_0" => self.scale[0] = value,
+            "scale_1" => self.scale[1] = value,
+            "scale_2" => self.scale[2] = value,
+            "opacity" => self.opacity = value,
+            "f_dc_0" => self.f_dc[0] = value,
+            "f_dc_1" => self.f_dc[1] = value,
+            "f_dc_2" => self.f_dc[2] = value,
+            _ => {
+                match key 
+                .strip_prefix("f_rest_")
+                .and_then(|s| s.parse::<usize>().ok())
+                {
+                    Some(i) if i < MAX_SH => self.f_rest[i] = value,
+                    _ => return PropertyAccessResult::Ignored
+                }
+            }
+        }
+        PropertyAccessResult::Set
+    }
+
+    fn set_uchar(&mut self, key: &str, value: u8) -> PropertyAccessResult {
+        match key {
+            "red" => self.red = value,
+            "green" => self.green = value,
+            "blue" => self.blue = value,
+            _ => return PropertyAccessResult::Ignored
+        }
+        PropertyAccessResult::Set
+    }
+}
 
 pub fn deserialize_ply(raw_assets: &mut RawAssets, path: &PathBuf) -> Result<Scene> {
     let name = path.to_str().unwrap().to_string();
     let bytes = raw_assets.get(path)?;
     let mut cursor = Cursor::new(bytes); // wrap with a position tracker
 
-    let parser = Parser::<DefaultElement>::new();
+    let parser = Parser::<GsSplat>::new();
     let ply = parser.read_ply(&mut cursor)?;
+
+    // read header
+    let mut reader = Reader::new(Cursor::new(bytes));
+    let header = parser.read_header(&mut reader)?;
+    let vertex_def = header.elements.get("vertex").ok_or_else(|| crate::Error::FailedDeserialize(name.clone()))?;
+
+    // checking ply type
+    let has_uchar_colors = vertex_def.properties.contains_key("red");
+    let has_gs_fields = vertex_def.properties.contains_key("scale_0")
+        && vertex_def.properties.contains_key("rot_0")
+        && vertex_def.properties.contains_key("opacity")
+        && vertex_def.properties.contains_key("f_dc_0");
+
+    let mut sh_coeff_count = 0;
+    while vertex_def.properties.contains_key(&format!("f_rest_{}", sh_coeff_count)) {
+        sh_coeff_count += 1;
+    }
+    sh_coeff_count = sh_coeff_count.min(MAX_SH);
 
     let vertices = ply
         .payload
@@ -22,24 +109,6 @@ pub fn deserialize_ply(raw_assets: &mut RawAssets, path: &PathBuf) -> Result<Sce
     let num_vertices = vertices.len();
     let mut positions = Vec::with_capacity(num_vertices);
 
-    // check for traditional uchar color fields
-    let first_vertex = vertices.first();
-    let has_uchar_colors = first_vertex.is_some_and(|v| v.get_uchar("red").is_some());
-
-    // check for gaussian splat fields, including color, scale, rotation, opacity, and spherical harmonic coefficients
-    let has_gs_fields = first_vertex.is_some_and(|v| {
-        v.get_float("scale_0").is_some()
-            && v.get_float("rot_0").is_some()
-            && v.get_float("opacity").is_some()
-            && v.get_float("f_dc_0").is_some()
-    });
-
-    // check for spherical harmonic coefficients
-    let mut sh_coeff_count = 0;
-    while first_vertex.is_some_and(|v| v.get_float(&format!("f_rest_{}", sh_coeff_count)).is_some())
-    {
-        sh_coeff_count += 1;
-    }
 
     let mut colors = if has_uchar_colors {
         Some(Vec::with_capacity(num_vertices))
@@ -73,22 +142,22 @@ pub fn deserialize_ply(raw_assets: &mut RawAssets, path: &PathBuf) -> Result<Sce
 
     // some ply files may not have spherical harmonic coefficients ( only f_dc_* )
     let mut spherical_harmonics = if has_gs_fields && sh_coeff_count > 0 {
-        Some(Vec::with_capacity(num_vertices))
+        Some(Vec::with_capacity(num_vertices * sh_coeff_count))
     } else {
         None
     };
 
     for vertex in vertices {
         positions.push(vec3(
-            vertex.get_float("x").unwrap_or(0.0),
-            vertex.get_float("y").unwrap_or(0.0),
-            vertex.get_float("z").unwrap_or(0.0),
+            vertex.position[0],
+            vertex.position[1],
+            vertex.position[2],
         ));
 
         if has_uchar_colors {
-            let r = vertex.get_uchar("red").unwrap_or(0);
-            let g = vertex.get_uchar("green").unwrap_or(0);
-            let b = vertex.get_uchar("blue").unwrap_or(0);
+            let r = vertex.red;
+            let g = vertex.green;
+            let b = vertex.blue;
             if let Some(ref mut c) = colors {
                 c.push(Srgba {
                     r,
@@ -98,44 +167,43 @@ pub fn deserialize_ply(raw_assets: &mut RawAssets, path: &PathBuf) -> Result<Sce
                 });
             }
         } else if has_gs_fields {
-            // f_dc_0, f_dc_1, f_dc_2 for degree 0) spherical harmonic coefficients
-            let f_dc_0 = vertex.get_float("f_dc_0").unwrap_or(0.0);
-            let f_dc_1 = vertex.get_float("f_dc_1").unwrap_or(0.0);
-            let f_dc_2 = vertex.get_float("f_dc_2").unwrap_or(0.0);
-
             // scale
-            let scale_x = vertex.get_float("scale_0").unwrap_or(1.0);
-            let scale_y = vertex.get_float("scale_1").unwrap_or(1.0);
-            let scale_z = vertex.get_float("scale_2").unwrap_or(1.0);
+            let scale_x = vertex.scale[0];
+            let scale_y = vertex.scale[1];
+            let scale_z = vertex.scale[2];
             if let Some(ref mut s) = scale {
                 s.push(vec3(scale_x, scale_y, scale_z));
             }
 
             // rotation
-            let rot_w = vertex.get_float("rot_0").unwrap_or(1.0);
-            let rot_x = vertex.get_float("rot_1").unwrap_or(0.0);
-            let rot_y = vertex.get_float("rot_2").unwrap_or(0.0);
-            let rot_z = vertex.get_float("rot_3").unwrap_or(0.0);
+            let rot_w = vertex.rotation[0];
+            let rot_x = vertex.rotation[1];
+            let rot_y = vertex.rotation[2];
+            let rot_z = vertex.rotation[3];
             if let Some(ref mut r) = rotation {
                 r.push(Quat::from_sv(rot_w, vec3(rot_x, rot_y, rot_z)));
             }
 
             // opacity;
             if let Some(ref mut o) = opacity {
-                o.push(vertex.get_float("opacity").unwrap_or(1.0));
+                o.push(vertex.opacity);
             }
 
+            // f_dc_0, f_dc_1, f_dc_2 for degree 0) spherical harmonic coefficients
+            let f_dc_0 = vertex.f_dc[0];
+            let f_dc_1 = vertex.f_dc[1];
+            let f_dc_2 = vertex.f_dc[2];
             // degree 0 spherical harmonic coefficients
             if let Some(ref mut dc0) = dc_spherical_harmonics {
                 dc0.push(vec3(f_dc_0, f_dc_1, f_dc_2));
             }
 
-            if let Some(ref mut s) = spherical_harmonics {
-                let coeffs = (0..sh_coeff_count)
-                    .map(|i| vertex.get_float(&format!("f_rest_{}", i)).unwrap_or(0.0))
-                    .collect();
-                s.push(coeffs);
+            // spherical harmonic coefficients
+            if let Some(ref mut sh) = spherical_harmonics {
+                sh.extend_from_slice(&vertex.f_rest[0..sh_coeff_count]);
             }
+
+            
         }
     }
 

--- a/src/io/ply.rs
+++ b/src/io/ply.rs
@@ -2,11 +2,11 @@ use crate::geometry::{Geometry, PointCloud, Positions};
 use crate::prelude::*;
 use crate::{io::RawAssets, Node, Result, Scene};
 use ply_rs_bw::parser::{Parser, Reader};
-use ply_rs_bw::ply::{ PropertyAccess, PropertyAccessResult};
+use ply_rs_bw::ply::{PropertyAccess, PropertyAccessResult};
 use std::io::Cursor;
 use std::path::PathBuf;
 
-const MAX_SH:usize = 45;
+const MAX_SH: usize = 45;
 
 struct GsSplat {
     position: [f32; 3],
@@ -52,12 +52,12 @@ impl PropertyAccess for GsSplat {
             "f_dc_1" => self.f_dc[1] = value,
             "f_dc_2" => self.f_dc[2] = value,
             _ => {
-                match key 
-                .strip_prefix("f_rest_")
-                .and_then(|s| s.parse::<usize>().ok())
+                match key
+                    .strip_prefix("f_rest_")
+                    .and_then(|s| s.parse::<usize>().ok())
                 {
                     Some(i) if i < MAX_SH => self.f_rest[i] = value,
-                    _ => return PropertyAccessResult::Ignored
+                    _ => return PropertyAccessResult::Ignored,
                 }
             }
         }
@@ -69,7 +69,7 @@ impl PropertyAccess for GsSplat {
             "red" => self.red = value,
             "green" => self.green = value,
             "blue" => self.blue = value,
-            _ => return PropertyAccessResult::Ignored
+            _ => return PropertyAccessResult::Ignored,
         }
         PropertyAccessResult::Set
     }
@@ -86,7 +86,10 @@ pub fn deserialize_ply(raw_assets: &mut RawAssets, path: &PathBuf) -> Result<Sce
     // read header
     let mut reader = Reader::new(Cursor::new(bytes));
     let header = parser.read_header(&mut reader)?;
-    let vertex_def = header.elements.get("vertex").ok_or_else(|| crate::Error::FailedDeserialize(name.clone()))?;
+    let vertex_def = header
+        .elements
+        .get("vertex")
+        .ok_or_else(|| crate::Error::FailedDeserialize(name.clone()))?;
 
     // checking ply type
     let has_uchar_colors = vertex_def.properties.contains_key("red");
@@ -96,7 +99,10 @@ pub fn deserialize_ply(raw_assets: &mut RawAssets, path: &PathBuf) -> Result<Sce
         && vertex_def.properties.contains_key("f_dc_0");
 
     let mut sh_coeff_count = 0;
-    while vertex_def.properties.contains_key(&format!("f_rest_{}", sh_coeff_count)) {
+    while vertex_def
+        .properties
+        .contains_key(&format!("f_rest_{}", sh_coeff_count))
+    {
         sh_coeff_count += 1;
     }
     sh_coeff_count = sh_coeff_count.min(MAX_SH);
@@ -108,7 +114,6 @@ pub fn deserialize_ply(raw_assets: &mut RawAssets, path: &PathBuf) -> Result<Sce
 
     let num_vertices = vertices.len();
     let mut positions = Vec::with_capacity(num_vertices);
-
 
     let mut colors = if has_uchar_colors {
         Some(Vec::with_capacity(num_vertices))
@@ -202,8 +207,6 @@ pub fn deserialize_ply(raw_assets: &mut RawAssets, path: &PathBuf) -> Result<Sce
             if let Some(ref mut sh) = spherical_harmonics {
                 sh.extend_from_slice(&vertex.f_rest[0..sh_coeff_count]);
             }
-
-            
         }
     }
 


### PR DESCRIPTION
# PLY memory optimizations

Optimizes Gaussian splat PLY loading by replacing the generic `DefaultElement` parser with a typed `GsSplat` vertex struct, and flattening `f_rest` storage in `PointCloud`.

Benchmarked on `test_data/grape_small.ply` (5,000 splats). Baseline: `DefaultElement` parser with `spherical_harmonics: Vec<Vec<f32>>`.

## Changes

1. **Typed `GsSplat` parser** — implements `PropertyAccess` with fixed `f32`/`u8` arrays instead of `DefaultElement`'s dynamic per-vertex property map.
2. **Flat `f_rest` storage** — `spherical_harmonics` is now `Vec<f32>` (interleaved per-splat coeffs) instead of `Vec<Vec<f32>>`.

**Breaking:** `spherical_harmonics` layout changed. Coeffs for splat `i` are at `sh[i * coeff_count .. (i + 1) * coeff_count]` (45 for grape test files).

## Results (`grape_small.ply`)

| Metric | Baseline | After | Saved | % saved |
|--------|----------|-------|------:|--------:|
| Peak heap (deserialize) | 44.64 MiB | 3.53 MiB | 41.11 MiB | **92.1%** |
| Retained `PointCloud` | 1.24 MiB | 1.13 MiB | 0.11 MiB | **9.2%** |

| Field | Before | After |
|-------|-------:|------:|
| spherical_harmonics | 0.973 MiB | 0.858 MiB |
| **Total** | **1.240 MiB** | **1.125 MiB** |

The parser change mainly reduces **peak heap** during load (less temporary allocation while parsing). Flat `f_rest` reduces **retained** size by removing per-splat `Vec` overhead (~120 KiB on this file).
